### PR TITLE
chore: enforce minimum dependency age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 # Approved dependency build scripts (see `pnpm approve-builds`)
 allowBuilds:
   lefthook: true
+
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Enforce a seven-day minimum release age for pnpm dependencies.

## Metadata change

Added `minimumReleaseAge: 10080` to `pnpm-workspace.yaml`.

## Verification

Inspected `git status`, the working-tree diff, and the staged diff to confirm that only the requested metadata file changed. Package-manager commands, tests, linters, formatters, builds, and validators were intentionally not run.